### PR TITLE
Add OrderedDict YAML representer

### DIFF
--- a/lava_results_app/dbutils.py
+++ b/lava_results_app/dbutils.py
@@ -43,8 +43,12 @@ from lava_common.timeout import Timeout
 def yaml_decimal_str(dumper, value):
     return yaml.ScalarNode(tag=u"tag:yaml.org,2002:str", value=str(value))
 
+def yaml_ordered_dict_ordered_mapping(dumper, value):
+    return dumper.represent_mapping('tag:yaml.org,2002:omap', value.items())
+
 
 yaml.add_representer(decimal.Decimal, yaml_decimal_str)
+yaml.add_representer(collections.OrderedDict, yaml_ordered_dict_mapping)
 
 
 def _check_for_testset(result_dict, suite):


### PR DESCRIPTION
This is to prevent Lava to include `object/apply` constructs such as:
  !!python/object/apply:collections.OrderedDict
in the yaml files made available through XMLRPC endpoints.

This became more problematic recently when PyYAML version 5.2 was
released which made the usage of the `load()` method raise an error when
using `object/apply` as it can be used as an attack vector.

Because Lava produces yaml files with `object/apply` constructs PyYAML
5.2 fails to parse them using the regular `load()` method. We have to
use the compatibility `unsafe_load()` method.

I believe producing such constructs is not on purpose because we can see
a commit [1] preventing the use of `object/apply` for another Python
type.

This commit adds a representer to convert the OrderedDict to yaml's
Ordered Mapping.

[1] https://github.com/Linaro/lava/commit/14b347c51efb89e8d6c64d9aa74fb4190f03227c

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>