### PR TITLE
[Scheduler] Change logger message var type

### DIFF
--- a/lava_scheduler_app/scheduler.py
+++ b/lava_scheduler_app/scheduler.py
@@ -390,4 +390,4 @@ def transition_multinode_jobs(logger):
             # transition the job and device
             sub_job.go_state_scheduled()
             sub_job.save()
-            logger.debug("--> %d", sub_job.id)
+            logger.debug("--> %s", sub_job.id)


### PR DESCRIPTION
I keep getting errors when I submit multinode jobs:
![image](https://user-images.githubusercontent.com/62895232/223166523-1202fa7e-83fd-4716-b49a-8bc684190a6e.png)
